### PR TITLE
Bug fix - v0.10.0 date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## DEV
+## Version 0.10.0 (2025-09-07)
 
 - **Breaking**: improve logging system, by supporting log levels and filtering. The `dp.log` function is removed: `dp.PolicyEnv` must be used instead.
 - Add `interactive` option to experiment launcher, allowing to obtain a snapshot of ongoing tasks at any time by pressing Enter.
 - Automatically add time information in logs.
 - Logging now supports arbitrary serializable metadata.
 - Fix a deprecation warning on Python 3.13.
+- Fix a bug in `delphyne check`.
 
 ## Version 0.9.2 (2025-09-03)
 

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ repomix:
 # is valid for the latest stable release.
 deploy-doc-release:
 	git fetch origin gh-pages
-	mike deploy 0.9 latest --update-aliases --push
+	mike deploy 0.10 latest --update-aliases --push
 
 
 # Build and deploy the documentation for the dev version

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ First, download the Delphyne repository and enter it:
 ```sh
 git clone git@github.com:jonathan-laurent/delphyne.git
 cd delphyne
-git checkout v0.9.2  # latest stable version
+git checkout v0.10.0  # latest stable version
 ```
 
 Then, to install the Delphyne library and CLI in your current Python environment:

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,7 +99,7 @@ First, download the Delphyne repository and enter it:
 ```sh
 git clone git@github.com:jonathan-laurent/delphyne.git
 cd delphyne
-git checkout v0.9.2  # latest stable version
+git checkout v0.10.0  # latest stable version
 ```
 
 Then, to install the Delphyne library and CLI in your current Python environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delphyne"
-version = "0.9.2"
+version = "0.10.0"
 description = ""
 authors = [{name="Jonathan Laurent", email="jonathan.laurent@cs.cmu.edu"}]
 readme = "README.md"

--- a/src/delphyne/server/basic_launcher.py
+++ b/src/delphyne/server/basic_launcher.py
@@ -74,7 +74,8 @@ class BasicLauncher(TaskLauncher):
                     break
                 if not context.messages_queue.empty():
                     message = context.messages_queue.get_nowait()
-                    yield json.dumps(adapter.dump_python(message)) + "\n\n"
+                    # Use Pydantic's JSON serializer to handle datetimes and other types.
+                    yield adapter.dump_json(message).decode() + "\n\n"
                 else:
                     await asyncio.sleep(_CONNECTION_POLLING_TIME)
         finally:

--- a/vscode-ui/package.json
+++ b/vscode-ui/package.json
@@ -4,7 +4,7 @@
   "description": "Language support for Delphyne in VSCode",
   "repository": "https://github.com/jonathan-laurent/delphyne",
   "publisher": "jonathan-laurent",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "icon": "media/logo/delphyne.png",
   "engines": {
     "vscode": "^1.89.0"


### PR DESCRIPTION
Unfortunately v0.10.0 has a bug. `Execute-command` does not work.

By inspecting the error commands, it appears to be related to `json` not being able to serialize the date.

I propose using Pydantic's JSON serializer, as it can handle datetimes.