### PR TITLE
Bug - date serialization (v0.10.0)

### DIFF
--- a/src/delphyne/server/basic_launcher.py
+++ b/src/delphyne/server/basic_launcher.py
@@ -74,7 +74,7 @@ class BasicLauncher(TaskLauncher):
                     break
                 if not context.messages_queue.empty():
                     message = context.messages_queue.get_nowait()
-                    yield json.dumps(adapter.dump_python(message)) + "\n\n"
+                    yield adapter.dump_json(message).decode() + "\n\n"
                 else:
                     await asyncio.sleep(_CONNECTION_POLLING_TIME)
         finally:


### PR DESCRIPTION
Unfortunately v0.10.0 has a bug. `Execute-command `does not work.

By inspecting the error commands, it appears to be related to ` json` not being able to serialize the date.

I propose using Pydantic's JSON serializer, as it can handle datetimes.

Edit: I re-did the PR without the bump version. Once accepted, I will close the other one.